### PR TITLE
Fixed Add-XMLItem Known Issue

### DIFF
--- a/Misc/xXMLConfigFileCommonFunctions.psm1
+++ b/Misc/xXMLConfigFileCommonFunctions.psm1
@@ -225,7 +225,12 @@ function Add-XMLItem {
             }
             else {
                 #get parent node
-                $Parent=$root.SelectSingleNode($XPath,$ns).get_ParentNode()
+                if ($root.SelectSingleNode($XPath,$ns) -eq $null){
+                    # Take one step back in XPath to add first element
+                    $Parent=$root.SelectSingleNode(($XPath.SubString(0, $XPath.LastIndexOf('/'))),$ns)
+                } else {
+                    $Parent=$root.SelectSingleNode($XPath,$ns).get_ParentNode()
+                }
                 #create element
                 $Element = $xml.CreateElement($($XPath.Split('/')[-1] -replace ("$($NSPrefix):","")),$NamespaceURI)
                 #create attributes


### PR DESCRIPTION
enhanced Add-XMLItem to fix multiple attributes in an element known issue. This also allows creation of first child element/attribute node