### PR TITLE
Added support for changing more than one element

### DIFF
--- a/DSCResources/xXMLConfigFile/xXMLConfigFile.psm1
+++ b/DSCResources/xXMLConfigFile/xXMLConfigFile.psm1
@@ -18,7 +18,7 @@ function Get-TargetResource
         [System.String]
         $XPath,
 
-        [parameter(Mandatory = $false)]
+        [parameter(Mandatory = $true)]
         [System.String]
         $Name,
 
@@ -92,7 +92,7 @@ function Set-TargetResource
         [System.String]
         $XPath,
 
-        [parameter(Mandatory = $false)]
+        [parameter(Mandatory = $true)]
         [System.String]
         $Name,
 
@@ -183,7 +183,7 @@ function Test-TargetResource
         [System.String]
         $XPath,
 
-        [parameter(Mandatory = $false)]
+        [parameter(Mandatory = $true)]
         [System.String]
         $Name,
 

--- a/DSCResources/xXMLConfigFile/xXMLConfigFile.schema.mof
+++ b/DSCResources/xXMLConfigFile/xXMLConfigFile.schema.mof
@@ -4,7 +4,7 @@ class xXMLConfigFile : OMI_BaseResource
 {
     [Key, Description("Path to config file")] String ConfigPath;
     [Key, Description("XPath to use")] String XPath;
-    [Write, Description("Name of the attribute/element")] String Name;
+    [Key, Description("Name of the attribute/element")] String Name;
     [Write, Description("Value of the attribute")] String Value;
     [Write, Description("Name is attribute")] Boolean isAttribute;
     [Write, Description("Name is element only")] Boolean isElementTextValue;


### PR DESCRIPTION
Added support for changing more than one element under same parent in the same configuration.

You might need to change two elements under the same parent element.
`
<TopNode>
   <ChildNode>SomeText</ChildNode>
   <ChildNode2>SomeText2</ChildNode2>
</TopNode>

`
Currently that is not supported as two config elements referencing the same XPath and FilePath will result in an DSC error as they (in combination) are not unique.

I do not see any situation (I might be wrong), where you do not want to have a Name parameter. Therefore making this a Key would solve this problem.
