### PR TITLE
Change null value check to detect if parameter is specified

### DIFF
--- a/Misc/xXMLConfigFileCommonFunctions.psm1
+++ b/Misc/xXMLConfigFileCommonFunctions.psm1
@@ -411,7 +411,7 @@ function Add-XMLItem
                     $Element = $xml.CreateElement($Name,$NamespaceURI)
     
                     #set value
-                    if ($null -ne $Value)
+                    if ($PSBoundParameters.ContainsKey("Value"))
                     {
                         $Element.set_InnerText($Value)
                     }
@@ -433,7 +433,7 @@ function Add-XMLItem
                     $Element = $xml.CreateElement($Name)
     
                     #set value
-                    if ($null -ne $Value)
+                    if ($PSBoundParameters.ContainsKey("Value"))
                     {
                         $Element.set_InnerText($Value)
                     }


### PR DESCRIPTION
Current check for null will never trigger as the parameter value will always be an empty string and not null even if null is specified in the DSC configuration. Using PSBoundParameters instead will correctly detect if the vlaue parameter is not specified or set to null.